### PR TITLE
Small fix to work with Ruby 1.9.x

### DIFF
--- a/lib/html5.rb
+++ b/lib/html5.rb
@@ -62,7 +62,7 @@ module ActionView::Helpers
   end
 
   class FormBuilder
-    self.field_helpers = (FormHelper.instance_methods - ['form_for'])
+    self.field_helpers = (FormHelper.instance_methods.map(&:to_s) - ['form_for'])
     
     (field_helpers - %w(label check_box radio_button fields_for hidden_field)).each do |selector|
       src = <<-end_src


### PR DESCRIPTION
Hey,

We've been using this on a Rails project that we're in the process of upgrading to use Ruby 1.9.3, and I stumbled across a small gotcha in the code. 

In Ruby 1.8.x, #instance_methods returns an array of Strings, whereas in 1.9.x it returns Symbols. This was causing problems with the library no longer filtering out the FormHelper methods that should not be overwritten.

I've patched that in the commit in this pull request. I'm not sure how actively this project is being maintained, but if it still is, here's the fix.

Thanks!

--Michael
